### PR TITLE
TrackingStatus to return \DateTime for object created/updated

### DIFF
--- a/src/Entity/RootEntity.php
+++ b/src/Entity/RootEntity.php
@@ -24,7 +24,7 @@ abstract class RootEntity extends Entity
     /**
      * Date and time of object creation.
      *
-     * @return string
+     * @return \DateTime
      */
     public function getObjectCreated()
     {
@@ -34,7 +34,7 @@ abstract class RootEntity extends Entity
     /**
      * Date and time of last object update.
      *
-     * @return string
+     * @return \DateTime
      */
     public function getObjectUpdated()
     {

--- a/src/Entity/TrackingStatus.php
+++ b/src/Entity/TrackingStatus.php
@@ -9,21 +9,21 @@ class TrackingStatus extends Entity
     /**
      * Date and time of object creation.
      *
-     * @return string
+     * @return \DateTime
      */
     public function getObjectCreated()
     {
-        return $this->attributes->mayHave('object_created')->asString();
+        return $this->attributes->mayHave('object_created')->asInstance('\\DateTime');
     }
 
     /**
      * Date and time of last object update.
      *
-     * @return string
+     * @return \DateTime
      */
     public function getObjectUpdated()
     {
-        return $this->attributes->mayHave('object_updated')->asString();
+        return $this->attributes->mayHave('object_updated')->asInstance('\\DateTime');
     }
 
     /**


### PR DESCRIPTION
ShippoClient\Entity\TrackingStatus to return DateTime instance instead of string for methods of getting object's create and update date/time.
