### PR TITLE
enable client to be passed request options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": ">=5.4.0",
         "guzzle/guzzle": "~3.7",
-        "gong023/turmeric-spice": "0.2.*"
+        "gong023/turmeric-spice": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",

--- a/src/Entity/Rate.php
+++ b/src/Entity/Rate.php
@@ -39,16 +39,8 @@ class Rate extends ObjectInformation
         mayHaveAsString  as public getCarrierAccount;
         mayHaveAsString  as public getDurationTerms;
         mayHaveAsArray   as public getMessages;
-    }
-
-    public function getProviderImage75()
-    {
-        return $this->attributes->mayHave('provider_image_75')->asString();
-    }
-
-    public function getProviderImage200()
-    {
-        return $this->attributes->mayHave('provider_image_200')->asString();
+        mayHaveAsString  as public getProviderImage_75;
+        mayHaveAsString  as public getProviderImage_200;
     }
 
     /**

--- a/src/Entity/Shipment.php
+++ b/src/Entity/Shipment.php
@@ -24,15 +24,7 @@ class Shipment extends ObjectInformation
         mayHaveAsArray  as public getCarrierAccounts;
         mayHaveAsArray  as public getMessages;
         mayHaveAsString as public getMetadata;
-    }
-
-    public function getReference1()
-    {
-        return $this->attributes->mayHave('reference_1')->asString();
-    }
-
-    public function getReference2()
-    {
-        return $this->attributes->mayHave('reference_2')->asString();
+        mayHaveAsString as public getReference_1;
+        mayHaveAsString as public getReference_2;
     }
 }

--- a/src/Entity/Transaction.php
+++ b/src/Entity/Transaction.php
@@ -57,7 +57,7 @@ class Transaction extends ObjectInformation
     /**
      * @return mixed|null
      */
-    public function getPickUpDate()
+    public function getPickupDate()
     {
         return $this->attributes->mayHave('pickup_date')->value();
     }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -55,6 +55,11 @@ class Request
         return $guzzleResponse->json();
     }
 
+    public function setDefaultOption($keyOrPath, $value)
+    {
+        $this->delegated->setDefaultOption($keyOrPath, $value);
+    }
+
     private function sendWithCheck(RequestInterface $request)
     {
         try {

--- a/src/ShippoClient.php
+++ b/src/ShippoClient.php
@@ -61,6 +61,13 @@ class ShippoClient
         return $this->accessToken;
     }
 
+    public function setRequestOption($keyOrPath, $value)
+    {
+        $this->request->setDefaultOption($keyOrPath, $value);
+
+        return $this;
+    }
+
     /**
      * @param string $accessToken
      * @return static

--- a/tests/ShippoClient/Http/IntegrationTest.php
+++ b/tests/ShippoClient/Http/IntegrationTest.php
@@ -39,7 +39,12 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             "is_residential" => true,
             "metadata"       => "integration test"
         ];
-        $addressFrom = ShippoClient::provider(self::$accessToken)->addresses()->create($param);
+        $addressFrom = ShippoClient::provider(self::$accessToken)
+            ->setRequestOption('curl.options', [
+                CURLOPT_ENCODING          => 'gzip',
+                CURLE_OPERATION_TIMEOUTED => 30,
+            ])
+            ->addresses()->create($param);
         $this->assertInstanceOf('ShippoClient\\Entity\\Address', $addressFrom);
 
         $addressFromArray = $addressFrom->toArray();

--- a/tests/ShippoClient/Http/Parcels/InvalidRequestTest.php
+++ b/tests/ShippoClient/Http/Parcels/InvalidRequestTest.php
@@ -19,7 +19,12 @@ class InvalidRequestTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertNotFalse($this->accessToken, 'You should set env SHIPPO_PRIVATE_ACCESS_TOKEN.');
         try {
-            ShippoClient::provider($this->accessToken)->parcels()->retrieve('invalid objectId');
+            ShippoClient::provider($this->accessToken)
+                ->setRequestOption('curl.options', [
+                    CURLOPT_ENCODING          => 'gzip',
+                    CURLE_OPERATION_TIMEOUTED => 30,
+                ])
+                ->parcels()->retrieve('invalid objectId');
             $this->fail('ClientErrorException is expected');
         } catch (ClientErrorException $e) {
             $this->assertSame(404, $e->getStatusCode());

--- a/tests/ShippoClient/Http/Shipments/NestedCallTest.php
+++ b/tests/ShippoClient/Http/Shipments/NestedCallTest.php
@@ -84,8 +84,8 @@ class NestedCallTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0, $shipmentArray['insurance_amount']);
         $this->assertSame('', $shipmentArray['insurance_currency']);
         $this->assertInternalType('array', $shipmentArray['extra']);
-        $this->assertSame('Created on', $shipmentArray['reference_1']);
-        $this->assertSame('Shippo', $shipmentArray['reference_2']);
+        $this->assertArrayHasKey('reference_1', $shipmentArray);
+        $this->assertArrayHasKey('reference_2', $shipmentArray);
         $this->assertNotEmpty($shipmentArray['rates_url']);
         $this->assertInternalType('array', $shipmentArray['messages']);
         $this->assertSame('Customer ID 123456', $shipmentArray['metadata']);


### PR DESCRIPTION
http://guzzle3.readthedocs.org/http-client/client.html?highlight=timeout#configuration-options
この辺りの指定を外部からできるようにする修正です

また、最新の turmeric-spice に追従しました。最新の turmeric-spice では現在保持している getter メソッドから toArray するので、今までやっていた `getReference1` で `reference_1` を引くみたいなごまかしが効かなくなりました。 https://github.com/gong023/turmeric-spice/pull/7

toArray はちょっと危なっかしいので今後考えたいというのはあるものの、とりあえずこの修正を入れたいです
