### PR TITLE
Fixed the case of empty tracking status value

### DIFF
--- a/src/Entity/StandaloneTrack.php
+++ b/src/Entity/StandaloneTrack.php
@@ -17,8 +17,13 @@ class StandaloneTrack
      */
     public function getTrackingStatus()
     {
-        return $this->attributes->mayHave('tracking_status')
-            ->asInstanceOf('\\ShippoClient\\Entity\\TrackingStatus');
+        $tracking_status = $this->attributes->mayHave('tracking_status');
+
+        if (!$tracking_status->value()) {
+            return new TrackingStatus();
+        }
+
+        return $tracking_status->asInstanceOf('\\ShippoClient\\Entity\\TrackingStatus');
     }
 
     /**


### PR DESCRIPTION
間違ったtrackingNumberを指定した場合にvalueが空になることがあるので、からっぽのTrackingStatus()を返すようにしました
