### PR TITLE
Only ascii characters are used in addresses

### DIFF
--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -8,13 +8,6 @@ use TurmericSpice\ReadableAttributes;
 class Address extends ObjectInformation
 {
     use ReadableAttributes {
-        mayHaveAsString as public getName;
-        mayHaveAsString as public getCompany;
-        mayHaveAsString as public getStreet1;
-        mayHaveAsString as public getStreet2;
-        mayHaveAsString as public getStreetNo;
-        mayHaveAsString as public getCity;
-        mayHaveAsString as public getState;
         mayHaveAsString as public getZip;
         mayHaveAsString as public getCountry;
         mayHaveAsString as public getPhone;
@@ -22,6 +15,41 @@ class Address extends ObjectInformation
         mayHaveAsString as public getIp;
         mayHaveAsString as public getMetadata;
         mayHaveAsArray  as public getMessages;
+    }
+
+    public function getName()
+    {
+        return $this->mayHaveAsAsciiString('name');
+    }
+
+    public function getCompany()
+    {
+        return $this->mayHaveAsAsciiString('company');
+    }
+
+    public function getStreet1()
+    {
+        return $this->mayHaveAsAsciiString('street1');
+    }
+
+    public function getStreet2()
+    {
+        return $this->mayHaveAsAsciiString('street2');
+    }
+
+    public function getStreetNo()
+    {
+        return $this->mayHaveAsAsciiString('street_no');
+    }
+
+    public function getCity()
+    {
+        return $this->mayHaveAsAsciiString('city');
+    }
+
+    public function getState()
+    {
+        return $this->mayHaveAsAsciiString('state');
     }
 
     public function getIsResidential()
@@ -32,5 +60,32 @@ class Address extends ObjectInformation
         }
 
         return (bool)$is_residential;
+    }
+
+    private function mayHaveAsAsciiString($propertyName, callable $validate = null)
+    {
+        return $this->transliterateToAscii(
+            $this->attributes->mayHave($propertyName)->asString($validate)
+        );
+    }
+
+    private function mustHaveAsAsciiString($propertyName, callable $validate = null)
+    {
+        return $this->transliterateToAscii(
+            $this->attributes->mustHave($propertyName)->asString($validate)
+        );
+    }
+
+    private function transliterateToAscii($str)
+    {
+        $ret = '';
+        foreach (preg_split('//u', $str) as $ch) {
+            $ch = @iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $ch);
+            if (strlen($ch) > 1) {
+                $ch = preg_replace('/[^0-9A-Za-z]/', '', $ch);
+            }
+            $ret .= $ch;
+        }
+        return $ret;
     }
 }

--- a/tests/ShippoClient/Entity/AddressTest.php
+++ b/tests/ShippoClient/Entity/AddressTest.php
@@ -16,7 +16,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     {
         $address = new Address([
             'name'      => 'Hello world!',
-            'company'   => 'ŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"`\'^~',
+            'company'   => 'ŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"`\'^~',
             'street1'   => 'ŻŹĆŃĄŚŁĘÓżźćńąśłęó"`\'^~',
             'street2'   => 'Γειά σου Κόσμε!',
             'street_no' => '세계 안녕하세요!',
@@ -26,7 +26,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
 
         $this->assert()
             ->same('Hello world!', $address->getName())
-            ->same('SOEZsoezYuAAAAAAAECEEEEIIIIDNOOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy"`\'^~', $address->getCompany())
+            ->same('SOEZsoezYuAAAAAAAECEEEEIIIINOOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy"`\'^~', $address->getCompany())
             ->same('ZZCNASLEOzzcnasleo"`\'^~', $address->getStreet1())
             ->same('  !', $address->getStreet2())
             ->same(' !', $address->getStreetNo())

--- a/tests/ShippoClient/Entity/AddressTest.php
+++ b/tests/ShippoClient/Entity/AddressTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ShippoClient\Http\Request\Refunds;
+
+use AssertChain\AssertChain;
+use ShippoClient\Entity\Address;
+
+class AddressTest extends \PHPUnit_Framework_TestCase
+{
+    use AssertChain;
+
+    /**
+     * @test
+     */
+    public function transliterateToAscii()
+    {
+        $address = new Address([
+            'name'      => 'Hello world!',
+            'company'   => 'ŠŒŽšœžŸ¥µÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýÿ"`\'^~',
+            'street1'   => 'ŻŹĆŃĄŚŁĘÓżźćńąśłęó"`\'^~',
+            'street2'   => 'Γειά σου Κόσμε!',
+            'street_no' => '세계 안녕하세요!',
+            'city'      => 'こんにちは世界！',
+            'state'     => '你好，世界！',
+        ]);
+
+        $this->assert()
+            ->same('Hello world!', $address->getName())
+            ->same('SOEZsoezYyenuAAAAAAAECEEEEIIIIDNOOOOOOUUUUYssaaaaaaaeceeeeiiiidnoooooouuuuyy"`\'^~', $address->getCompany())
+            ->same('ZZCNASLEOzzcnasleo"`\'^~', $address->getStreet1())
+            ->same('  !', $address->getStreet2())
+            ->same(' !', $address->getStreetNo())
+            ->same('!', $address->getCity())
+            ->same(',!', $address->getState());
+    }
+}

--- a/tests/ShippoClient/Entity/AddressTest.php
+++ b/tests/ShippoClient/Entity/AddressTest.php
@@ -16,7 +16,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     {
         $address = new Address([
             'name'      => 'Hello world!',
-            'company'   => 'ŠŒŽšœžŸ¥µÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýÿ"`\'^~',
+            'company'   => 'ŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"`\'^~',
             'street1'   => 'ŻŹĆŃĄŚŁĘÓżźćńąśłęó"`\'^~',
             'street2'   => 'Γειά σου Κόσμε!',
             'street_no' => '세계 안녕하세요!',
@@ -26,7 +26,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
 
         $this->assert()
             ->same('Hello world!', $address->getName())
-            ->same('SOEZsoezYyenuAAAAAAAECEEEEIIIIDNOOOOOOUUUUYssaaaaaaaeceeeeiiiidnoooooouuuuyy"`\'^~', $address->getCompany())
+            ->same('SOEZsoezYuAAAAAAAECEEEEIIIIDNOOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy"`\'^~', $address->getCompany())
             ->same('ZZCNASLEOzzcnasleo"`\'^~', $address->getStreet1())
             ->same('  !', $address->getStreet2())
             ->same(' !', $address->getStreetNo())

--- a/tests/ShippoClient/Entity/AddressTest.php
+++ b/tests/ShippoClient/Entity/AddressTest.php
@@ -16,7 +16,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
     {
         $address = new Address([
             'name'      => 'Hello world!',
-            'company'   => 'ŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"`\'^~',
+            'company'   => 'ŠŒŽšœžŸµÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝßàáâãäåæçèéêëìíîïñòóôõöùúûüýÿ"`\'^~',
             'street1'   => 'ŻŹĆŃĄŚŁĘÓżźćńąśłęó"`\'^~',
             'street2'   => 'Γειά σου Κόσμε!',
             'street_no' => '세계 안녕하세요!',
@@ -26,7 +26,7 @@ class AddressTest extends \PHPUnit_Framework_TestCase
 
         $this->assert()
             ->same('Hello world!', $address->getName())
-            ->same('SOEZsoezYuAAAAAAAECEEEEIIIINOOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy"`\'^~', $address->getCompany())
+            ->same('SOEZsoezYuAAAAAAAECEEEEIIIINOOOOOUUUUYssaaaaaaaeceeeeiiiinooooouuuuyy"`\'^~', $address->getCompany())
             ->same('ZZCNASLEOzzcnasleo"`\'^~', $address->getStreet1())
             ->same('  !', $address->getStreet2())
             ->same(' !', $address->getStreetNo())


### PR DESCRIPTION
Getters to return arbitrary string in an Address object should transliterate (or remove) non ascii characters to avoid errors on shipping label creation.
