### PR TITLE
Add support for Tracking Substatus

### DIFF
--- a/src/Entity/Substatus.php
+++ b/src/Entity/Substatus.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ShippoClient\Entity;
+
+use TurmericSpice\ReadableAttributes;
+
+class Substatus {
+    use ReadableAttributes {
+        mayHaveAsString  as public getCode;
+        mayHaveAsString  as public getText;
+        mayHaveAsBoolean as public getActionRequired;
+    }
+}

--- a/src/Entity/TrackingStatus.php
+++ b/src/Entity/TrackingStatus.php
@@ -69,6 +69,16 @@ class TrackingStatus
         return new Location($attributes);
     }
 
+    /**
+     * @return Substatus
+     */
+    public function getSubstatus()
+    {
+        $attributes = $this->attributes->mayHave('substatus')->asArray();
+
+        return new Substatus($attributes);
+    }
+
     public function toArray()
     {
         return [
@@ -78,6 +88,7 @@ class TrackingStatus
             'status'         => $this->getStatus(),
             'status_date'    => $this->getStatusDate(),
             'status_details' => $this->getStatusDetails(),
+            'substatus'      => $this->getSubstatus()->toArray(),
             'location'       => $this->getLocation()->toArray(),
         ];
     }


### PR DESCRIPTION
## What
- Adds support for an attribute added in Shippo 2018-02-08.
- See: https://goshippo.com/docs/tracking/#event-definitions

Here is an example:
```
"tracking_status": {
    "status_date": "2021-08-27T20:37:56Z",
    "status_details": "Delivered",
    "location": {
      "city": "Hibbing",
      "state": "MN",
      "zip": "55746",
      "country": "US"
    },
    "substatus": {
      "code": "delivered",
      "text": "Package has been delivered.",
      "action_required": false
    },
    "object_created": "2021-08-27T23:23:19.532Z",
    "object_updated": "2021-08-27T23:23:19.532Z",
    "object_id": "omited",
    "status": "DELIVERED"
  },
"tracking_history": [
    .
    .
    {
      "status_date": "2021-08-27T20:37:56Z",
      "status_details": "Delivered",
      "location": {
        "city": "Hibbing",
        "state": "MN",
        "zip": "55746",
        "country": "US"
      },
      "substatus": {
        "code": "delivered",
        "text": "Package has been delivered.",
        "action_required": false
      },
      "object_created": "2021-08-27T23:23:19.532Z",
      "object_updated": "2021-08-27T23:23:19.532Z",
      "object_id": "omitted",
      "status": "DELIVERED"
    }
  ],
```

## Why
- `substatus` is very helpful for user context
- Its a field supported in latest Shippo API
- Updating `TrackingStatus` also updates `TrackingHistory` as well which is what we want.